### PR TITLE
Fix: Add keep-alive scheduler to prevent Render hibernation (Issue #500)

### DIFF
--- a/src/main/java/dev/razafindratelo/arsmedia/ArsmediaApplication.java
+++ b/src/main/java/dev/razafindratelo/arsmedia/ArsmediaApplication.java
@@ -1,10 +1,13 @@
 package dev.razafindratelo.arsmedia;
 
+import dev.razafindratelo.arsmedia.InfraGenerated;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @InfraGenerated
 @SpringBootApplication
+@EnableScheduling
 public class ArsmediaApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/dev/razafindratelo/arsmedia/config/HttpClientConf.java
+++ b/src/main/java/dev/razafindratelo/arsmedia/config/HttpClientConf.java
@@ -1,0 +1,24 @@
+package dev.razafindratelo.arsmedia.config;
+
+import dev.razafindratelo.arsmedia.InfraGenerated;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Configuration for HTTP client utilities.
+ */
+@InfraGenerated
+@Configuration
+public class HttpClientConf {
+
+  /**
+   * Provides a RestTemplate bean for synchronous HTTP calls.
+   *
+   * @return configured RestTemplate instance
+   */
+  @Bean
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
+  }
+}

--- a/src/main/java/dev/razafindratelo/arsmedia/config/RenderKeepAliveScheduler.java
+++ b/src/main/java/dev/razafindratelo/arsmedia/config/RenderKeepAliveScheduler.java
@@ -1,0 +1,44 @@
+package dev.razafindratelo.arsmedia.config;
+
+import dev.razafindratelo.arsmedia.InfraGenerated;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Scheduled keep-alive task to prevent Render free tier from hibernating.
+ *
+ * <p>Pings the application's own health endpoint every 9 minutes to keep the service active.
+ * Render free tier services hibernate after 15 minutes of inactivity.
+ */
+@InfraGenerated
+@Component
+@Slf4j
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "render.keepalive.enabled", havingValue = "true", matchIfMissing = true)
+public class RenderKeepAliveScheduler {
+
+  private final RestTemplate restTemplate;
+
+  /**
+   * Pings the local health endpoint every 9 minutes to prevent hibernation.
+   *
+   * <p>Render free tier hibernates after 15 minutes of inactivity. This task runs every 9 minutes
+   * to ensure the service stays awake.
+   */
+  @Scheduled(fixedRateString = "540000") // 9 minutes in milliseconds
+  public void keepAlive() {
+    try {
+      ResponseEntity<String> response = restTemplate.getForEntity("http://localhost:8080/ping", String.class);
+      if (response.getStatusCode().value() == 200) {
+        log.debug("Keep-alive ping successful");
+      }
+    } catch (Exception e) {
+      log.warn("Keep-alive ping failed: {}", e.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR fixes the health check failures caused by Render free tier hibernation.

## Changes
1. Added `RenderKeepAliveScheduler` - A scheduled task that pings the `/ping` endpoint every 9 minutes to keep the service active
2. Added `HttpClientConf` - Configuration class providing RestTemplate bean
3. Enabled `@EnableScheduling` in `ArsmediaApplication`

## Root Cause
Render free tier services hibernate after 15 minutes of inactivity, causing health check requests to return 503 errors.

## Solution
The scheduler runs every 9 minutes (540000ms) to make an internal HTTP request to the health endpoint, preventing the service from entering hibernation state.

## Testing
- The scheduler is conditional and can be disabled via `render.keepalive.enabled=false` property
- Logs keep-alive success/failure at DEBUG/WARN level

Fixes issue #500